### PR TITLE
Small fixes for test suite, undefined global

### DIFF
--- a/lglob
+++ b/lglob
@@ -726,7 +726,7 @@ local function check_globals (file, args)
     if load_requires then -- any globals from require(mod) are ok
         for _,item in ipairs(requires) do
             if dump then print('requiring',item.module) end
-            local ok,mod, injected
+            local ok,mod,names,injected
             if require_whitelist then -- resolve module in this table
                 local pkg,name = splitname(item.module)
                 local base = require_whitelist

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -37,7 +37,7 @@ for _,case in ipairs(cases) do
             -- grab the expected result from appropriate comments
             local testr = {}
             for line in ff:lines() do
-                local x = line:match '%-%-~ (.+)'
+                local x = line:match '%-%-~ ([^\r]+)'
                 if x then table.insert(testr,x) end
             end
             -- which we expect to match!

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -34,18 +34,22 @@ for _,case in ipairs(cases) do
         end
         if not passed then
             local ff = io.open(file,'r')
-            -- grab the expected result from appropriate comments
-            local testr = {}
-            for line in ff:lines() do
-                local x = line:match '%-%-~ ([^\r]+)'
-                if x then table.insert(testr,x) end
-            end
-            -- which we expect to match!
-            testr = table.concat(testr,'\n')..'\n'
-            if testr ~= res then
-                print('case ',file,' did not fail properly!\n')
-                print('+'..testr)
-                print('-'..res)
+            if ff then
+                -- grab the expected result from appropriate comments
+                local testr = {}
+                for line in ff:lines() do
+                    local x = line:match '%-%-~ ([^\r]+)'
+                    if x then table.insert(testr,x) end
+                end
+                -- which we expect to match!
+                testr = table.concat(testr,'\n')..'\n'
+                if testr ~= res then
+                    print('case '..file..' did not fail properly!\n')
+                    print('+'..testr)
+                    print('-'..res)
+                end
+            else
+                print('case '..file..' not found!\n')
             end
         end
         f:close()


### PR DESCRIPTION
The carriage return issue resulted in this annoying message:

```
case lhs.lua did not fail properly!

+lglob: lhs.lua:1: undefined set foo
lglob: lhs.lua:2: redefining global print

-lglob: lhs.lua:1: undefined set foo
lglob: lhs.lua:2: redefining global print
```

The "case file not found" issue is actually that `testwl.lua` is apparently not committed, but the test suite might as well deal with it. Still, if you have it, maybe you should commit it :)

The undefined global is obvious.
